### PR TITLE
Script update & update button change

### DIFF
--- a/virtual-launchpad.json
+++ b/virtual-launchpad.json
@@ -1,5 +1,8 @@
 {
-  "session": {
+  "version": "1.16.0",
+  "type": "session",
+  "createdWith": "Open Stage Control",
+  "content": {
     "type": "root",
     "id": "root",
     "visible": true,
@@ -25,7 +28,6 @@
     "value": "",
     "default": "",
     "linkId": "",
-    "script": "",
     "address": "auto",
     "preArgs": "",
     "typeTags": "",
@@ -60,7 +62,6 @@
         "value": "",
         "default": "",
         "linkId": "",
-        "script": "",
         "address": "auto",
         "preArgs": "",
         "typeTags": "",
@@ -103,7 +104,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "auto",
             "preArgs": "",
             "typeTags": "",
@@ -144,7 +144,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -154,7 +153,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -188,7 +191,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -198,7 +200,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -232,7 +238,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -242,7 +247,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -276,7 +285,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -286,7 +294,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -320,7 +332,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -330,7 +341,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -364,7 +379,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -374,7 +388,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -408,7 +426,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -418,7 +435,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -452,7 +473,6 @@
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -462,7 +482,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -491,12 +515,11 @@
                 "wrap": false,
                 "on": 1,
                 "off": 0,
-                "mode": "tap",
+                "mode": "toggle",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/control",
                 "preArgs": [
                   1,
@@ -506,10 +529,18 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               }
             ],
-            "tabs": []
+            "tabs": [],
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -538,12 +569,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -553,7 +583,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -582,12 +616,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -597,7 +630,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -626,12 +663,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -641,7 +677,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -670,12 +710,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -685,7 +724,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -714,12 +757,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -729,7 +771,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -758,12 +804,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -773,7 +818,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -802,12 +851,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -817,7 +865,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -846,12 +898,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -861,7 +912,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "panel",
@@ -897,7 +952,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "auto",
             "preArgs": "",
             "typeTags": "",
@@ -933,12 +987,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -948,7 +1001,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -977,12 +1034,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -992,7 +1048,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1021,12 +1081,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1036,7 +1095,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1065,12 +1128,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1080,7 +1142,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1109,12 +1175,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1124,7 +1189,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1153,12 +1222,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1168,7 +1236,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1197,12 +1269,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1212,7 +1283,11 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               },
               {
                 "type": "button",
@@ -1241,12 +1316,11 @@
                 "wrap": false,
                 "on": 127,
                 "off": 0,
-                "mode": "tap",
+                "mode": "push",
                 "doubleTap": false,
                 "value": "",
                 "default": "",
                 "linkId": "",
-                "script": "",
                 "address": "/note",
                 "preArgs": [
                   1,
@@ -1256,10 +1330,18 @@
                 "decimals": 2,
                 "target": "midi:virtual-launchpad",
                 "ignoreDefaults": false,
-                "bypass": false
+                "bypass": false,
+                "onValue": "",
+                "lock": false,
+                "comments": "",
+                "onCreate": ""
               }
             ],
-            "tabs": []
+            "tabs": [],
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1288,12 +1370,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1303,7 +1384,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1332,12 +1417,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1347,7 +1431,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1376,12 +1464,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1391,7 +1478,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1420,12 +1511,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1435,7 +1525,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1464,12 +1558,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1479,7 +1572,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1508,12 +1605,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1523,7 +1619,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1552,12 +1652,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1567,7 +1666,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1596,12 +1699,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1611,7 +1713,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1640,12 +1746,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1655,7 +1760,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1684,12 +1793,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1699,7 +1807,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1728,12 +1840,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1743,7 +1854,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1772,12 +1887,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1787,7 +1901,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1816,12 +1934,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1831,7 +1948,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1860,12 +1981,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1875,7 +1995,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1904,12 +2028,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1919,7 +2042,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1948,12 +2075,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -1963,7 +2089,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -1992,12 +2122,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2007,7 +2136,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2036,12 +2169,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2051,7 +2183,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2080,12 +2216,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2095,7 +2230,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2124,12 +2263,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2139,7 +2277,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2168,12 +2310,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2183,7 +2324,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2212,12 +2357,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2227,7 +2371,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2256,12 +2404,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2271,7 +2418,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2300,12 +2451,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2315,7 +2465,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2344,12 +2498,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2359,7 +2512,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2388,12 +2545,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2403,7 +2559,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2432,12 +2592,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2447,7 +2606,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2476,12 +2639,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2491,7 +2653,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2520,12 +2686,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2535,7 +2700,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2564,12 +2733,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2579,7 +2747,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2608,12 +2780,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2623,7 +2794,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2652,12 +2827,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2667,7 +2841,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2696,12 +2874,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2711,7 +2888,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2740,12 +2921,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2755,7 +2935,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2784,12 +2968,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2799,7 +2982,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2828,12 +3015,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2843,7 +3029,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2872,12 +3062,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2887,7 +3076,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2916,12 +3109,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2931,7 +3123,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -2960,12 +3156,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -2975,7 +3170,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3004,12 +3203,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3019,7 +3217,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3048,12 +3250,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3063,7 +3264,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3092,12 +3297,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3107,7 +3311,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3136,12 +3344,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3151,7 +3358,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3180,12 +3391,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3195,7 +3405,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3224,12 +3438,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3239,7 +3452,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3268,12 +3485,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3283,7 +3499,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3312,12 +3532,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3327,7 +3546,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3356,12 +3579,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3371,7 +3593,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3400,12 +3626,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3415,7 +3640,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3444,12 +3673,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3459,7 +3687,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3488,12 +3720,11 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3503,7 +3734,11 @@
             "decimals": 2,
             "target": "midi:virtual-launchpad",
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3529,7 +3764,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3542,12 +3776,16 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3573,7 +3811,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3586,12 +3823,16 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3617,7 +3858,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3630,12 +3870,16 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3661,7 +3905,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3674,12 +3917,16 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "button",
@@ -3705,7 +3952,6 @@
             "value": "",
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "/note",
             "preArgs": [
               1,
@@ -3718,12 +3964,16 @@
             "wrap": false,
             "on": 127,
             "off": 0,
-            "mode": "tap",
+            "mode": "push",
             "doubleTap": false,
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           },
           {
             "type": "variable",
@@ -3791,20 +4041,30 @@
             },
             "default": "",
             "linkId": "",
-            "script": "",
             "address": "auto",
             "preArgs": "",
             "target": "",
             "typeTags": "",
             "decimals": 2,
             "ignoreDefaults": false,
-            "bypass": false
+            "bypass": false,
+            "onValue": "",
+            "lock": false,
+            "comments": "",
+            "onCreate": ""
           }
         ],
-        "tabs": []
+        "tabs": [],
+        "onValue": "",
+        "lock": false,
+        "comments": "",
+        "onCreate": ""
       }
-    ]
-  },
-  "version": "1.8.12",
-  "type": "Open Stage Control session"
+    ],
+    "onValue": "",
+    "lock": false,
+    "comments": "",
+    "hideMenu": false,
+    "onCreate": ""
+  }
 }


### PR DESCRIPTION
The new version has 3 changes:
- Changed all clip buttons from 'tap' action to 'push' which allows for more consistent results when communicating with Ableton Live
- Changed update button from 'tap' to 'toggle' so the clip buttons can be temporarily disabled (Tested with Ableton Live 11.1 only)
- Several attributes have been added - shouldn't change functionality - by the automatic version conversion in Open Stage Control (script updated from OSC v1.8.12 to v1.16.0)